### PR TITLE
DQM plotting script using TApplication

### DIFF
--- a/analysis/TBdraw.cc
+++ b/analysis/TBdraw.cc
@@ -8,9 +8,14 @@
 #include "TPad.h"
 #include "TString.h"
 #include "TFile.h"
+#include "TApplication.h"
+#include "TRootCanvas.h"
 
-int TBdraw(int runNum) {
-    TFile* hist_file = TFile::Open( (("DQM_Run") + std::to_string(runNum) + ".root").c_str() );
+int main(int argc, char* argv[]) {
+    TApplication app("app", &argc, argv);
+
+    std::string runNum = argv[1];
+    TFile* hist_file = TFile::Open( (("DQM_Run") + runNum + ".root").c_str() );
 
     TList* hist_list = hist_file->GetListOfKeys();
     std::vector<std::string> hist_name_list;
@@ -41,9 +46,9 @@ int TBdraw(int runNum) {
         pad_idx++;
     }
 
-    std::cout << "Type any key if you want to quit..." << std::endl;
-    std::string key;
-    std::cin >> key;
+    TRootCanvas *rc = (TRootCanvas *)c->GetCanvasImp();
+    rc->Connect("CloseWindow()", "TApplication", gApplication, "Terminate()");
+    app.Run();
     
     hist_file->Close();
     return 0;

--- a/analysis/TBdraw.cc
+++ b/analysis/TBdraw.cc
@@ -1,0 +1,50 @@
+#include <string>
+#include <iostream>
+#include <vector>
+
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TH1.h"
+#include "TPad.h"
+#include "TString.h"
+#include "TFile.h"
+
+int TBdraw(int runNum) {
+    TFile* hist_file = TFile::Open( (("DQM_Run") + std::to_string(runNum) + ".root").c_str() );
+
+    TList* hist_list = hist_file->GetListOfKeys();
+    std::vector<std::string> hist_name_list;
+    for(int idx = 0; idx < hist_list->GetEntries(); idx++) {
+        hist_name_list.emplace_back( (std::string) hist_list->At(idx)->GetName() );
+        std::cout << hist_name_list.at(idx) << std::endl;
+    }
+
+    TCanvas* c = new TCanvas("c", "c", 1200, 800);
+    c->Divide(hist_name_list.size() - hist_name_list.size()/2, hist_name_list.size()/2);
+    c->Update();
+    c->Draw();
+    int pad_idx = 1;
+    for (std::string hist_name : hist_name_list) {
+        c->cd(pad_idx);
+        std::string plot_type = hist_name.substr(0, hist_name.find("_"));
+        std::string MIDandCh  = hist_name.substr(hist_name.find("_")+1);
+        std::string MID = MIDandCh.substr( MIDandCh.find("Mid") + 3, MIDandCh.find("Ch") - MIDandCh.find("Mid") - 3 );
+        std::string Ch  = MIDandCh.substr( MIDandCh.find("Ch") + 2);
+        std::cout << "Drawing plot : " << plot_type << " with MID : " << MID << " Ch : " << Ch << std::endl;
+        
+        TH1F* hist = (TH1F*) hist_file->Get(hist_name.c_str());
+        hist->SetTitle(plot_type.c_str());
+        if (plot_type == "AvgTimeStruc") hist->SetStats(0);
+        hist->Draw("Hist");
+        c->Modified();
+        c->Update();
+        pad_idx++;
+    }
+
+    std::cout << "Type any key if you want to quit..." << std::endl;
+    std::string key;
+    std::cin >> key;
+    
+    hist_file->Close();
+    return 0;
+}

--- a/analysis/TBdraw.py
+++ b/analysis/TBdraw.py
@@ -3,8 +3,12 @@ from ROOT import TFile
 from ROOT import TCanvas
 from ROOT import TH1
 from ROOT import TList
+from ROOT import TApplication
+from ROOT import TRootCanvas
 
 import argparse
+
+app = TApplication("app", ROOT.nullptr, ROOT.nullptr)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--runNum", "-rn", type=str, required=True, action="store", help="run number of DQM file")
@@ -39,5 +43,8 @@ for hist_name in hist_name_list :
     c.Update()
     pad_idx += 1
 
-input("Type any key to exit...")
+rc = c.GetCanvasImp()
+rc.Connect("CloseWindow()", "TApplication", ROOT.gApplication, "Terminate()");
+app.Run()
+
 DQM_file.Close()

--- a/analysis/TBdraw.py
+++ b/analysis/TBdraw.py
@@ -8,6 +8,7 @@ from ROOT import TRootCanvas
 
 import argparse
 
+ROOT.gApplication = ROOT.nullptr
 app = TApplication("app", ROOT.nullptr, ROOT.nullptr)
 
 parser = argparse.ArgumentParser()

--- a/analysis/TBdraw.py
+++ b/analysis/TBdraw.py
@@ -1,0 +1,43 @@
+import ROOT
+from ROOT import TFile
+from ROOT import TCanvas
+from ROOT import TH1
+from ROOT import TList
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--runNum", "-rn", type=str, required=True, action="store", help="run number of DQM file")
+args = parser.parse_args()
+
+DQM_file = TFile.Open("DQM_Run" + args.runNum + ".root")
+hist_list = DQM_file.GetListOfKeys()
+
+hist_name_list = []
+for obj in hist_list :
+    hist_name_list.append(obj.GetName())
+
+c = TCanvas("c", "c", 1200, 800)
+c.Divide( len(hist_name_list) - int(len(hist_name_list)/2), int(len(hist_name_list)/2) )
+c.Update()
+c.Draw()
+
+pad_idx = 1
+for hist_name in hist_name_list :
+    plot_type = hist_name[ : hist_name.find("_")]
+    MID       = hist_name[hist_name.find("Mid")+3 : hist_name.find("Ch")]
+    Ch        = hist_name[hist_name.find("Ch")+2 : ]
+    print("Drawing plot : ", plot_type, " MID : ", MID, " Ch : ", Ch)
+
+    c.cd(pad_idx)
+    hist = DQM_file.Get(hist_name)
+    hist.SetTitle(plot_type)
+    if (plot_type == "AvgTimeStruc") :
+        hist.SetStats(0)
+    hist.Draw("Hist")
+    c.Modified()
+    c.Update()
+    pad_idx += 1
+
+input("Type any key to exit...")
+DQM_file.Close()

--- a/analysis/compile.sh
+++ b/analysis/compile.sh
@@ -1,7 +1,14 @@
 #! /bin/bash
 
-# g++ -I$INSTALL_DIR_PATH/include -L$INSTALL_DIR_PATH/lib $INSTALL_DIR_PATH/lib/libdrcTB.so `root-config --cflags --libs` $1.cc -o $1
+# To compile TBxxx.cc, type the commnand below
+# `bash compile.sh TBxxx.cc` (or `bash compile.sh TBxxx.cc` for short)
+# This will generate TBxxx executable
+
+ext=${1##*.}
+fname=`basename ${1} .${ext}`
+
+echo "Compiling $fname.cc to $fname"
 g++ \
 -I$INSTALL_DIR_PATH/include \
--L$INSTALL_DIR_PATH/lib $INSTALL_DIR_PATH/lib/libdrcTB.dylib $YAMLPATH/libyaml-cpp.dylib `root-config --cflags --libs` $1.cc -o $1
-
+-L$INSTALL_DIR_PATH/lib $INSTALL_DIR_PATH/lib/libdrcTB.dylib $YAMLPATH/libyaml-cpp.dylib `root-config --cflags --libs` ${fname}.cc -o ${fname}
+echo "Done!"

--- a/analysis/draw.sh
+++ b/analysis/draw.sh
@@ -1,5 +1,0 @@
-# !/bin/bash
-
-COMMAND="TBdraw.cc("${1}")"
-
-root -l -q ${COMMAND}

--- a/analysis/draw.sh
+++ b/analysis/draw.sh
@@ -1,0 +1,5 @@
+# !/bin/bash
+
+COMMAND="TBdraw.cc("${1}")"
+
+root -l -q ${COMMAND}


### PR DESCRIPTION
1. Reads DQM output ROOT file, identifies all histograms stored in it , draw all histograms in it.

2. Using TApplication, plot can be drawn & shown properly in both cpp and python.




3. Also slightly modified compile.sh code, so that

./compile.sh TBxxx.cc   and  ./compile.sh TBxxx

both can compile TBxxx.cc to create TBxxx executable